### PR TITLE
[#25] Improve Othello AI (corner discs)

### DIFF
--- a/game/othello/Constants.java
+++ b/game/othello/Constants.java
@@ -17,4 +17,6 @@ public final class Constants {
     // Evaluation
     public static final int VALUE_WIN = VALUE_UPPER_BOUND - 1;
     public static final int VALUE_LOSE = -VALUE_WIN;
+    public static final int CORNER_POINT = 8;
+    public static final int UNSTABLE_X_DEDUCTION = 5;
 }

--- a/game/othello/Evaluator.java
+++ b/game/othello/Evaluator.java
@@ -39,7 +39,7 @@ public class Evaluator extends BaseEvaluator {
             else
                 return VALUE_LOSE;
         }
-        return darkCnt - lightCnt + 0;
+        return darkCnt - lightCnt + getCornerAdjustment(b);
     }
 
     protected int getCornerAdjustment(Board board) {

--- a/game/othello/Evaluator.java
+++ b/game/othello/Evaluator.java
@@ -1,8 +1,11 @@
 package game.othello;
 
 import static game.othello.Constants.BOARD_SIZE;
+import static game.othello.Constants.CORNER_POINT;
 import static game.othello.Constants.DARK;
+import static game.othello.Constants.EMPTY;
 import static game.othello.Constants.LIGHT;
+import static game.othello.Constants.UNSTABLE_X_DEDUCTION;
 import static game.othello.Constants.VALUE_LOSE;
 import static game.othello.Constants.VALUE_WIN;
 
@@ -36,7 +39,29 @@ public class Evaluator extends BaseEvaluator {
             else
                 return VALUE_LOSE;
         }
-        return darkCnt - lightCnt;
+        return darkCnt - lightCnt + 0;
     }
 
+    protected int getCornerAdjustment(Board board) {
+        int res = 0;
+        res += getCornerValue(board.get(0, 0), board.get(1, 1));
+        res += getCornerValue(board.get(0, 7), board.get(1, 6));
+        res += getCornerValue(board.get(7, 0), board.get(6, 1));
+        res += getCornerValue(board.get(7, 7), board.get(6, 6));
+        return res;
+    }
+
+    protected int getCornerValue(int corner, int x) {
+        if (corner == EMPTY) {
+            if (x == DARK)
+                return -UNSTABLE_X_DEDUCTION;
+            else if (x == LIGHT)
+                return UNSTABLE_X_DEDUCTION;
+            return 0;
+        }
+        if (corner == DARK)
+            return CORNER_POINT;
+        else
+            return -CORNER_POINT;
+    }
 }


### PR DESCRIPTION
Modify Othello AI to regard corner discs highly.
'X' positions (b2, b7, g2, g7) with an empty correspondent corner will be considered unfavourable.