### PR TITLE
[#31] Fix return type of `clone()` in classes implementing `Cloneable`.

### DIFF
--- a/game/othello/Board.java
+++ b/game/othello/Board.java
@@ -27,7 +27,7 @@ public class Board extends BaseBoard {
     protected int[][] board;
 
     @Override
-    public BaseBoard clone() {
+    public Board clone() {
         Board cloned = new Board();
         for (int i = 0; i < board.length; i++)
             for (int j = 0; j < board[0].length; j++)

--- a/game/tictactoe/Board.java
+++ b/game/tictactoe/Board.java
@@ -10,7 +10,7 @@ public class Board extends BaseBoard {
     protected int[][] board;
 
     @Override
-    public BaseBoard clone() {
+    public Board clone() {
         Board cloned = new Board();
         for (int i = 0; i < board.length; i++)
             for (int j = 0; j < board[0].length; j++)


### PR DESCRIPTION
As described in #31.